### PR TITLE
Rubyの要求バージョンの値を2.3.0以上に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ superwowerのgithub page用レポジトリです。
 
 # Requirements
 ローカルで動作確認をする場合は以下のツールが必要です。
-- Ruby >=2.2.5
+- Ruby >=2.3.0
 - Gem
 - gcc, make
 


### PR DESCRIPTION
READMEの通りにruby 2.2.5の環境で動作させようとすると、以下のエラーが発生する。
```bash
# bundle install
Warning: the running version of Bundler (1.13.6) is older than the version that created the lockfile (1.16.2). We suggest you upgrade to the latest version of Bundler by running `gem install bundler`.
Fetching gem metadata from https://rubygems.org/...........
Fetching version metadata from https://rubygems.org/..
Fetching dependency metadata from https://rubygems.org/.
jekyll-seo-tag-2.5.0 requires ruby version >= 2.3.0, which is incompatible with
the current version, ruby 2.2.5p319
```